### PR TITLE
Allow file reuse

### DIFF
--- a/virtual.go
+++ b/virtual.go
@@ -45,7 +45,14 @@ func (fs *virtualFilesystem) Open(path string) (File, error) {
 	if !ok {
 		return nil, errNotFound{os.ErrNotExist}
 	}
-	return f, nil
+
+	return &virtualFile{
+		name:        f.name,
+		atime:       f.atime,
+		mtime:       f.mtime,
+		contentType: f.contentType,
+		buf:         *bytes.NewBuffer(f.buf.Bytes()),
+	}, nil
 }
 
 func (fs *virtualFilesystem) Rename(oldname, newname string) error {


### PR DESCRIPTION
In the virtual setup the file would not allow reuse between reads
and because of this, subsequent requests would cause any reads to
get the io.EOF error.

This change does the same as other environments and allows multiple
reads.